### PR TITLE
Path change for entering the node-fetch directory

### DIFF
--- a/node-fetch/README.md
+++ b/node-fetch/README.md
@@ -4,7 +4,7 @@ A sample node-fetch app containing GET and POST request integrated with keploy's
 ## Installation
 ### Setup node-fetch app
 ```bash
-git clone https://github.com/keploy/samples-typescript && cd node-fetch
+git clone https://github.com/keploy/samples-typescript && cd samples-typescript/node-fetch
 yarn
 ```
 ### Start keploy server


### PR DESCRIPTION
Git Cloning creates a seperate directory and then we have to enter the "node-fetch" directory under "samples-typescript" directory instead of directly accessing "node-fetch" directory from outside.