### PR TITLE
Doc Update for Running application in other OS

### DIFF
--- a/node-fetch/README.md
+++ b/node-fetch/README.md
@@ -19,8 +19,14 @@ For other operating system, follow [this guide](https://github.com/keploy/keploy
 
 
 ### Run the application
+For MacOS and Ubuntu 
 ```shell
 source .env && node server.js
+
+```
+For Windows 
+```shell
+setenv.bat && node server.js
 
 ```
 

--- a/node-fetch/setenv.bat
+++ b/node-fetch/setenv.bat
@@ -1,7 +1,7 @@
-setx KEPLOY_APP_NAME "sample-node-fetch" 
-setx KEPLOY_APP_HOST "localhost" 
-setx KEPLOY_APP_PORT 8080 
-setx KEPLOY_APP_DELAY 5 
-setx KEPLOY_APP_TIMEOUT 100 
-setx KEPLOY_SERVER_URL "localhost:6789" 
-setx KEPLOY_MODE "test" 
+setx KEPLOY_APP_NAME "sample-node-fetch" @REM App_Id for keploy
+setx KEPLOY_APP_HOST "localhost" @REM sample API server host
+setx KEPLOY_APP_PORT 8080 @REM Port on which the sample app is running
+setx KEPLOY_APP_DELAY 5 @REM Delay before running testcases in test mode. It should be number
+setx KEPLOY_APP_TIMEOUT 100 @REM request timeout for simulation of actual call in test mode. It should be number
+setx KEPLOY_SERVER_URL "localhost:6789" @REM URL on which keploy grpc server binary is running. Default: "localhost:6789"
+setx KEPLOY_MODE "record" @REM Mode on which sample API server starts running. Default: "off". Possible valid other values: "record" or "test"

--- a/node-fetch/setenv.bat
+++ b/node-fetch/setenv.bat
@@ -1,0 +1,7 @@
+setx KEPLOY_APP_NAME "sample-node-fetch" 
+setx KEPLOY_APP_HOST "localhost" 
+setx KEPLOY_APP_PORT 8080 
+setx KEPLOY_APP_DELAY 5 
+setx KEPLOY_APP_TIMEOUT 100 
+setx KEPLOY_SERVER_URL "localhost:6789" 
+setx KEPLOY_MODE "test" 

--- a/node-fetch/setenv.bat
+++ b/node-fetch/setenv.bat
@@ -1,7 +1,14 @@
-setx KEPLOY_APP_NAME "sample-node-fetch" @REM App_Id for keploy
-setx KEPLOY_APP_HOST "localhost" @REM sample API server host
-setx KEPLOY_APP_PORT 8080 @REM Port on which the sample app is running
-setx KEPLOY_APP_DELAY 5 @REM Delay before running testcases in test mode. It should be number
-setx KEPLOY_APP_TIMEOUT 100 @REM request timeout for simulation of actual call in test mode. It should be number
-setx KEPLOY_SERVER_URL "localhost:6789" @REM URL on which keploy grpc server binary is running. Default: "localhost:6789"
-setx KEPLOY_MODE "record" @REM Mode on which sample API server starts running. Default: "off". Possible valid other values: "record" or "test" 
+setx KEPLOY_APP_NAME "sample-node-fetch"
+@REM App_Id for keploy
+setx KEPLOY_APP_HOST "localhost" 
+@REM sample API server host
+setx KEPLOY_APP_PORT 8080 
+@REM Port on which the sample app is running
+setx KEPLOY_APP_DELAY 5 
+@REM Delay before running testcases in test mode. It should be number
+setx KEPLOY_APP_TIMEOUT 100 
+@REM request timeout for simulation of actual call in test mode. It should be number
+setx KEPLOY_SERVER_URL "localhost:6789" 
+@REM URL on which keploy grpc server binary is running. Default: "localhost:6789"
+setx KEPLOY_MODE "test" 
+@REM Mode on which sample API server starts running. Default: "off". Possible valid other values: "record" or "test" 

--- a/node-fetch/setenv.bat
+++ b/node-fetch/setenv.bat
@@ -4,4 +4,4 @@ setx KEPLOY_APP_PORT 8080 @REM Port on which the sample app is running
 setx KEPLOY_APP_DELAY 5 @REM Delay before running testcases in test mode. It should be number
 setx KEPLOY_APP_TIMEOUT 100 @REM request timeout for simulation of actual call in test mode. It should be number
 setx KEPLOY_SERVER_URL "localhost:6789" @REM URL on which keploy grpc server binary is running. Default: "localhost:6789"
-setx KEPLOY_MODE "record" @REM Mode on which sample API server starts running. Default: "off". Possible valid other values: "record" or "test"
+setx KEPLOY_MODE "record" @REM Mode on which sample API server starts running. Default: "off". Possible valid other values: "record" or "test" 


### PR DESCRIPTION
Source command doesn't work for windows so to set all environment variable at once, creating a bash file using the .bat extension that contains a set of commands to set env variable required.