### PR TITLE
Change EXPOSE to correct port in dockerfile

### DIFF
--- a/express-mongoose/Dockerfile
+++ b/express-mongoose/Dockerfile
@@ -19,5 +19,5 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-EXPOSE 8080
+EXPOSE 8000
 CMD [ "node", "src/app.js" ]


### PR DESCRIPTION
Since the service is set up to listen on port 8000 (refer to the compose file), we should change the expose to 8000