### PR TITLE
Improved Error Handling in /post Route

### DIFF
--- a/express-mongoose/src/routes/routes.js
+++ b/express-mongoose/src/routes/routes.js
@@ -77,22 +77,15 @@ router.delete('/student/:id', async(req,res) => {
 
 router.post('/post', async (req, res) => {
     try {
-        let data;
-        await axios.post('https://reqres.in/api/users', {
+        const response = await axios.post('https://reqres.in/api/users', {
             data: 'new data'
-        })
-            .then((response) => {
-                data = response.data
-            })
-            .catch((error) => {
-                console.error(error);
-            });
-        res.status(200).send(data);
-    }
-    catch (err) {
+        });
+        res.status(200).send(response.data);
+    } catch (err) {
         res.status(400).send(`Failed to post req data as ${err}`);
     }
-})
+});
+
 
 router.get('/get', async (req, res) => {
     try {


### PR DESCRIPTION
Refactored the /post route to ensure that if the axios.post() request fails, the API does not attempt to send an undefined response.
Previously, in case of a failure, the data variable would remain undefined due to the use of .catch() within await, and res.send(data) could return undefined, potentially confusing clients.

The axios.post() call is now wrapped inside a proper try-catch block, and response.data is returned only if the request is successful. This prevents the API from sending an undefined or malformed response to the client.