### PR TITLE
Add rate limiting middleware for API protection

### DIFF
--- a/express-mongodb/app.js
+++ b/express-mongodb/app.js
@@ -2,10 +2,20 @@ require('dotenv').config();
 
 const express = require("express");
 const mongoose = require("mongoose");
+const rateLimit = require("express-rate-limit");
 const Product = require("./models/product.model.js");
 const productRoute = require("./routes/product.route.js");
 const connectDB = require('./db/connect');
 const app = express();
+
+// Set up rate limiter
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100 // 100 requests per IP
+});
+
+// Add rate limiting to all routes
+app.use(limiter);
 
 // middleware
 app.use(express.json());

--- a/express-mongodb/package-lock.json
+++ b/express-mongodb/package-lock.json
@@ -13,6 +13,7 @@
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "express-rate-limit": "^7.5.0",
         "mongodb": "^6.5.0",
         "mongoose": "^8.1.0",
         "moongoose": "^0.0.5"
@@ -2243,6 +2244,21 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-json-stable-stringify": {

--- a/express-mongodb/package.json
+++ b/express-mongodb/package.json
@@ -16,6 +16,7 @@
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-rate-limit": "^7.5.0",
     "mongodb": "^6.5.0",
     "mongoose": "^8.1.0",
     "moongoose": "^0.0.5"


### PR DESCRIPTION
## Changes
- Added express-rate-limit package
- Set up rate limiting:
  - 15-minute window
  - 100 requests per IP
- Applied to all API routes

## Benefits
- Prevents API abuse
- Protects server resources
- Enhances security