### PR TITLE
feat(parse-server-mongo): minimal Parse Server + MongoDB sample

### DIFF
--- a/parse-server-mongo/Dockerfile
+++ b/parse-server-mongo/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl dumb-init && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm install --omit=dev
+
+COPY index.js ./
+
+EXPOSE 1337
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["node", "index.js"]

--- a/parse-server-mongo/README.md
+++ b/parse-server-mongo/README.md
@@ -1,0 +1,33 @@
+# parse-server-mongo
+
+Minimal Parse Server + MongoDB sample. Exists primarily as a falsifying e2e reproducer for the mongo/v2 boot-phase candidate-selection bug — a class of bug where an application issues the same query repeatedly during recording while DB state mutates, and the matcher's score-tied tiebreaker at replay picks the wrong same-shape mock.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `index.js` | 20-line Parse Server bootstrap; reads config from env |
+| `package.json` | Pins `parse-server@8.2.3` and `express@4.21.2` |
+| `Dockerfile` | `node:20-bookworm-slim` + `npm install --omit=dev` |
+| `docker-compose.yml` | mongo:7 + this sample, on a fixed-IP bridge network |
+| `flow.sh` | Minimum reproducer traffic — three HTTP calls |
+
+## What the bug is
+
+At boot, Parse Server runs `find _SCHEMA filter:{}` repeatedly during its eager-index sweep. While the recording captures these calls, the recording also drives Parse Server through a `POST /parse/classes/GameScore`, which lazily inserts the `GameScore` user-defined class into `_SCHEMA`. From that point onward, `find _SCHEMA` responses diverge — the early calls captured an empty / system-only `_SCHEMA`, the late ones captured `_SCHEMA` with `GameScore` present.
+
+At replay, the matcher has multiple same-shape candidates with diverging responses. Score-tied tiebreaker decides which one wins. The default tiebreaker picks the candidate closest to `mockWindowMaxReqTimestamp` (the latest recording timestamp), which biases toward late-recording mocks. The booting app then sees post-mutation `_SCHEMA`, takes the steady-state code path, and runs `listIndexes <user-class>` — a query the recording never witnessed, because at record time the user class wasn't in `_SCHEMA` at boot.
+
+The fix (in `keploy/integrations` mongo/v2 + a companion in `keploy/keploy` mockmanager) inverts the tiebreaker at boot phase to prefer the earliest same-shape candidate, and consumes startup-tier mocks on match so the next identical query advances to the next-earliest in chronological order.
+
+## Running locally
+
+```bash
+docker compose up -d
+bash flow.sh
+docker compose down -v
+```
+
+## How the e2e lane uses this sample
+
+The `parse-server-mongo` lane in `keploy/integrations` (`.woodpecker/parse-server-mongo.yml`) clones this repo, `cd`s into `parse-server-mongo/`, builds the sample image via `docker compose build`, runs `keploy record -c "docker compose -f docker-compose.yml up"` while `flow.sh` drives the three reproducer calls, then runs `keploy test` for the replay phase. Pass criteria: zero `mongo mock miss`, zero `MongoNetworkError`, zero `ParseError: schema class name does not revalidate` markers in the agent and app logs.

--- a/parse-server-mongo/docker-compose.yml
+++ b/parse-server-mongo/docker-compose.yml
@@ -1,0 +1,43 @@
+name: parse-server-mongo
+services:
+  mongo:
+    image: mongo:7
+    container_name: parse-server-mongo-mongo
+    networks:
+      parse-server-mongo-net:
+        ipv4_address: 172.30.0.10
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  parse-server:
+    build:
+      context: .
+    image: parse-server-mongo:local
+    container_name: parse-server-mongo-app
+    networks:
+      parse-server-mongo-net:
+        ipv4_address: 172.30.0.11
+    depends_on:
+      mongo:
+        condition: service_healthy
+    ports:
+      - "6100:6100"
+    environment:
+      PORT: "6100"
+      PARSE_MOUNT: "/parse"
+      PARSE_SERVER_APPLICATION_ID: keploy-parse-app
+      PARSE_SERVER_MASTER_KEY: keploy-parse-master
+      PARSE_SERVER_MASTER_KEY_IPS: 0.0.0.0/0,::0
+      PARSE_SERVER_SERVER_URL: http://localhost:6100/parse
+      PARSE_SERVER_DATABASE_URI: mongodb://172.30.0.10:27017/parse
+      PARSE_SERVER_ALLOW_CUSTOM_OBJECT_ID: "1"
+
+networks:
+  parse-server-mongo-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24

--- a/parse-server-mongo/flow.sh
+++ b/parse-server-mongo/flow.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Minimum reproducer traffic for the mongo/v2 boot-phase tiebreaker bug.
+#
+# Three calls produce the chronology divergence the lane needs:
+#   1. POST /parse/users (signup) — drives parse-server's boot find _SCHEMA
+#      sweep + insert _SCHEMA for system classes (_User, _Role, _Session, ...).
+#      All these mocks land before the user-defined class exists in _SCHEMA.
+#   2. POST /parse/classes/GameScore — parse-server lazily inserts the
+#      user-defined class into _SCHEMA AFTER its initial boot sweep,
+#      mutating state mid-recording. From this point onward, find _SCHEMA
+#      responses include GameScore.
+#   3. GET /parse/classes/GameScore/<id> — exercises the post-mutation
+#      state so the recording captures find _SCHEMA mocks with the
+#      diverged response shape.
+#
+# At replay, the boot-phase matcher's score-tied tiebreaker decides which
+# of the multiple same-shape find _SCHEMA mocks wins. Without the fix, it
+# picks the latest (post-GameScore-insertion); the booting app sees the
+# user class in _SCHEMA, runs `listIndexes <user-class>` (never recorded),
+# and dies with MongoNetworkError. With the fix, it picks the earliest
+# (pre-insertion); parse-server processes only system classes at boot,
+# the recorded follow-on queries match, and the app boots cleanly.
+
+set -Eeuo pipefail
+
+APP_PORT="${APP_PORT:-6100}"
+APP_ID="${PARSE_SERVER_APPLICATION_ID:-keploy-parse-app}"
+MASTER_KEY="${PARSE_SERVER_MASTER_KEY:-keploy-parse-master}"
+USER_ID="${USER_ID:-keploy-user-id}"
+SCORE_ID="${SCORE_ID:-keploy-score-id}"
+
+base="http://localhost:${APP_PORT}/parse"
+h_app=(-H "X-Parse-Application-Id: ${APP_ID}")
+h_master=(-H "X-Parse-Master-Key: ${MASTER_KEY}")
+h_json=(-H "Content-Type: application/json")
+
+echo "[flow] waiting for parse-server to come up..."
+for i in $(seq 1 180); do
+  if curl -fsS "${h_app[@]}" "${base}/health" >/dev/null 2>&1; then
+    echo "[flow] parse-server reachable"
+    break
+  fi
+  sleep 1
+done
+
+curl -fsS -X POST "${h_app[@]}" "${h_json[@]}" "${base}/users" \
+  --data "{\"objectId\":\"${USER_ID}\",\"username\":\"keploy-user\",\"password\":\"KeployPass123!\",\"email\":\"keploy@example.com\"}" \
+  >/dev/null
+echo "[flow] signup ok"
+
+curl -fsS -X POST "${h_app[@]}" "${h_master[@]}" "${h_json[@]}" "${base}/classes/GameScore" \
+  --data "{\"objectId\":\"${SCORE_ID}\",\"score\":10,\"playerName\":\"keploy-user\"}" \
+  >/dev/null
+echo "[flow] GameScore POST ok"
+
+curl -fsS "${h_app[@]}" "${h_master[@]}" "${base}/classes/GameScore/${SCORE_ID}" \
+  >/dev/null
+echo "[flow] GameScore GET ok"
+
+echo "[flow] complete"

--- a/parse-server-mongo/index.js
+++ b/parse-server-mongo/index.js
@@ -1,0 +1,27 @@
+// Minimal Parse Server bootstrap. The orchestration layer for an e2e
+// reproducer of the mongo/v2 boot-phase tiebreaker bug — parse-server's
+// own boot eager-index sweep is what the recording captures, and
+// flow.sh's POST /classes/GameScore is what mutates _SCHEMA mid-stream.
+const { ParseServer } = require('parse-server');
+const express = require('express');
+
+const app = express();
+const port = parseInt(process.env.PORT || '1337', 10);
+const mountPath = process.env.PARSE_MOUNT || '/parse';
+
+const parseServer = new ParseServer({
+  databaseURI: process.env.PARSE_SERVER_DATABASE_URI || 'mongodb://mongo:27017/parse',
+  appId: process.env.PARSE_SERVER_APPLICATION_ID || 'keploy-parse-app',
+  masterKey: process.env.PARSE_SERVER_MASTER_KEY || 'keploy-parse-master',
+  masterKeyIps: (process.env.PARSE_SERVER_MASTER_KEY_IPS || '0.0.0.0/0,::0').split(','),
+  serverURL: process.env.PARSE_SERVER_SERVER_URL || `http://localhost:${port}${mountPath}`,
+  allowCustomObjectId: process.env.PARSE_SERVER_ALLOW_CUSTOM_OBJECT_ID === '1',
+});
+
+(async () => {
+  await parseServer.start();
+  app.use(mountPath, parseServer.app);
+  app.listen(port, () => {
+    console.log(`parse-server-mongo listening on :${port}${mountPath}`);
+  });
+})();

--- a/parse-server-mongo/package.json
+++ b/parse-server-mongo/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "parse-server-mongo",
+  "version": "1.0.0",
+  "description": "Minimal Parse Server + MongoDB sample exercising the boot-phase chronology divergence: at startup, parse-server runs find _SCHEMA filter:{} repeatedly while flow.sh's traffic mid-stream inserts a user-defined class into _SCHEMA. The recording captures multiple same-shape mocks with diverging responses; the matcher's boot-phase tiebreaker must pick the earliest, and DeleteStartupMock must advance through the sequence on repeats.",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "4.21.2",
+    "parse-server": "8.2.3"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
## Summary

Adds a minimal Parse Server + MongoDB sample whose primary purpose is to serve as a falsifying e2e reproducer for a mongo/v2 boot-phase candidate-selection bug fixed in [keploy/integrations#166](https://github.com/keploy/integrations/pull/166) + [keploy/keploy#4158](https://github.com/keploy/keploy/pull/4158). Lives at `parse-server-mongo/` alongside the other entries in this repo.

## Layout

| File | Role |
|---|---|
| `index.js` | 20-line Parse Server bootstrap; reads config from env |
| `package.json` | Pins `parse-server@8.2.3` and `express@4.21.2` |
| `Dockerfile` | `node:20-bookworm-slim` + `npm install --omit=dev` |
| `docker-compose.yml` | `mongo:7` + this sample on a fixed-IP bridge network |
| `flow.sh` | Minimum reproducer traffic — three HTTP calls |
| `README.md` | What the sample exercises and how the lane uses it |

## What the sample exercises

At boot, Parse Server runs `find _SCHEMA filter:{}` repeatedly during its eager-index sweep. While the recording captures these calls, `flow.sh` drives Parse Server through a `POST /parse/classes/GameScore`, which lazily inserts the `GameScore` user-defined class into `_SCHEMA`. From that point onward, `find _SCHEMA` responses diverge — the early calls captured an empty / system-only `_SCHEMA`, the late ones captured `_SCHEMA` with `GameScore` present. At replay, the matcher has multiple same-shape candidates with diverging responses, and the score-tied tiebreaker decides which one wins.

The full root cause and fix are in [keploy/integrations#166](https://github.com/keploy/integrations/pull/166); this sample exists so the integrations lane has something to drive that doesn't live inside any of `keploy/keploy`, `keploy/integrations`, or `keploy/enterprise`.

## How the integrations lane uses this sample

The `parse-server-mongo` lane in [keploy/integrations](https://github.com/keploy/integrations/blob/fix/mongo-v2-boot-phase-tiebreaker/.woodpecker/parse-server-mongo.yml) clones this repo, `cd`s into `parse-server-mongo/`, builds the sample image via `docker compose build`, runs `keploy record -c "docker compose up"` while `flow.sh` drives the three reproducer calls, then runs `keploy test` for the replay phase. Pass criteria: zero `mongo mock miss`, zero `MongoNetworkError`, zero `ParseError: schema class name does not revalidate` markers in the agent and app logs.

The lane is pinned to this branch (`--branch feat/parse-server-mongo`) until this PR lands; once merged, the integrations lane drops the `--branch` pin in a follow-up.

## Test plan

- [x] `package.json` parses; `parse-server@8.2.3` is the latest stable on npm at time of writing
- [x] `docker-compose.yml` parses; mongo:7 + sample on `parse-server-mongo-net` (172.30.0.0/24)
- [x] `flow.sh` is executable; bash syntax validated
- [x] `Dockerfile` builds against `node:20-bookworm-slim`
- [ ] `docker compose up` + `flow.sh` runs end-to-end on a developer machine (verifying locally)
- [ ] integrations lane (in [keploy/integrations#166](https://github.com/keploy/integrations/pull/166)) goes green pinned to this branch

## Refs

- Sibling PRs: [keploy/integrations#166](https://github.com/keploy/integrations/pull/166), [keploy/keploy#4158](https://github.com/keploy/keploy/pull/4158)
- Methodology: keploy-ci-debug skill, step 9 ("End-to-end regression coverage: ship a falsifying lane alongside the unit fix") and step 4(f)