### PR TITLE
chore(parse-server-mongo): enrich flow.sh to reliably trigger boot-phase divergence

### DIFF
--- a/parse-server-mongo/flow.sh
+++ b/parse-server-mongo/flow.sh
@@ -1,25 +1,26 @@
 #!/usr/bin/env bash
-# Minimum reproducer traffic for the mongo/v2 boot-phase tiebreaker bug.
+# Reproducer traffic for the mongo/v2 boot-phase tiebreaker bug.
 #
-# Three calls produce the chronology divergence the lane needs:
-#   1. POST /parse/users (signup) — drives parse-server's boot find _SCHEMA
-#      sweep + insert _SCHEMA for system classes (_User, _Role, _Session, ...).
-#      All these mocks land before the user-defined class exists in _SCHEMA.
-#   2. POST /parse/classes/GameScore — parse-server lazily inserts the
-#      user-defined class into _SCHEMA AFTER its initial boot sweep,
-#      mutating state mid-recording. From this point onward, find _SCHEMA
-#      responses include GameScore.
-#   3. GET /parse/classes/GameScore/<id> — exercises the post-mutation
-#      state so the recording captures find _SCHEMA mocks with the
-#      diverged response shape.
+# What the bug needs to surface:
+#   - The recording captures multiple same-shape `find _SCHEMA filter:{}`
+#     mocks at boot, with diverging responses. Early ones see only
+#     system classes (_User, _Role, _Session, ...); later ones see
+#     user-defined classes Parse Server lazily added during traffic.
+#   - At replay, the matcher's score-tied tiebreaker picks ONE of those
+#     same-shape mocks. The unfixed tiebreaker biases toward the latest
+#     (with user classes), which steers a booting app onto a steady-
+#     state code path and runs `listIndexes <user-class>` for classes
+#     the boot phase didn't witness — surfacing as a downstream cascade
+#     mock-miss.
 #
-# At replay, the boot-phase matcher's score-tied tiebreaker decides which
-# of the multiple same-shape find _SCHEMA mocks wins. Without the fix, it
-# picks the latest (post-GameScore-insertion); the booting app sees the
-# user class in _SCHEMA, runs `listIndexes <user-class>` (never recorded),
-# and dies with MongoNetworkError. With the fix, it picks the earliest
-# (pre-insertion); parse-server processes only system classes at boot,
-# the recorded follow-on queries match, and the app boots cleanly.
+# To reliably trigger that divergence we (a) give Parse Server time to
+# complete its eager-index sweep before any HTTP test fires, and
+# (b) drive several class-mutating calls that each cause Parse Server
+# to refresh its schema cache and capture a new post-mutation
+# `find _SCHEMA` mock. The flow exercises three user classes
+# (GameScore, PlayerStats, Achievement) so the divergence window is
+# wide enough that even a one-off boot probe at replay will pick one
+# of the post-mutation mocks under the unfixed tiebreaker.
 
 set -Eeuo pipefail
 
@@ -27,7 +28,12 @@ APP_PORT="${APP_PORT:-6100}"
 APP_ID="${PARSE_SERVER_APPLICATION_ID:-keploy-parse-app}"
 MASTER_KEY="${PARSE_SERVER_MASTER_KEY:-keploy-parse-master}"
 USER_ID="${USER_ID:-keploy-user-id}"
+USERNAME="${USERNAME:-keploy-user}"
+PASSWORD="${PASSWORD:-KeployPass123!}"
+EMAIL="${EMAIL:-keploy@example.com}"
 SCORE_ID="${SCORE_ID:-keploy-score-id}"
+PLAYER_ID="${PLAYER_ID:-keploy-player-id}"
+ACHIEVEMENT_ID="${ACHIEVEMENT_ID:-keploy-achievement-id}"
 
 base="http://localhost:${APP_PORT}/parse"
 h_app=(-H "X-Parse-Application-Id: ${APP_ID}")
@@ -43,18 +49,67 @@ for i in $(seq 1 180); do
   sleep 1
 done
 
+# Give Parse Server a beat to finish its boot eager-index sweep so the
+# recording captures multiple pre-mutation find _SCHEMA snapshots
+# before any state mutation lands. Without this, all the find _SCHEMA
+# captures might come AFTER the first user class is inserted, so
+# there's no diverging same-shape candidate set for the matcher's
+# tiebreaker to contend over.
+sleep 3
+
+# --- Tier 1: read-only probes (no _SCHEMA mutation, but each handler
+# may cause Parse Server to refresh its schema cache, capturing more
+# pre-mutation find _SCHEMA snapshots) ---
+
+curl -fsS "${h_app[@]}" "${base}/health"      >/dev/null
+curl -fsS "${h_app[@]}" "${h_master[@]}" "${base}/serverInfo" >/dev/null
+curl -fsS "${h_app[@]}" "${h_master[@]}" "${base}/config"     >/dev/null
+curl -fsS "${h_app[@]}" "${h_master[@]}" "${base}/schemas"    >/dev/null
+echo "[flow] tier 1 (read-only probes) done"
+
+# --- Tier 2: signup + login (mutates _Session but not user classes) ---
+
 curl -fsS -X POST "${h_app[@]}" "${h_json[@]}" "${base}/users" \
-  --data "{\"objectId\":\"${USER_ID}\",\"username\":\"keploy-user\",\"password\":\"KeployPass123!\",\"email\":\"keploy@example.com\"}" \
+  --data "{\"objectId\":\"${USER_ID}\",\"username\":\"${USERNAME}\",\"password\":\"${PASSWORD}\",\"email\":\"${EMAIL}\"}" \
   >/dev/null
 echo "[flow] signup ok"
 
+curl -fsS "${h_app[@]}" "${base}/login?username=${USERNAME}&password=${PASSWORD}" >/dev/null
+echo "[flow] login ok"
+
+# --- Tier 3: user-class mutations. Each `POST /classes/<NewClass>`
+# triggers Parse Server to insert the class into _SCHEMA, refresh
+# its schema cache, and run listIndexes on the new collection. The
+# subsequent find _SCHEMA captures will include the newly-added
+# class. After three different classes, the recording's find
+# _SCHEMA mocks span four distinct response shapes. ---
+
 curl -fsS -X POST "${h_app[@]}" "${h_master[@]}" "${h_json[@]}" "${base}/classes/GameScore" \
-  --data "{\"objectId\":\"${SCORE_ID}\",\"score\":10,\"playerName\":\"keploy-user\"}" \
+  --data "{\"objectId\":\"${SCORE_ID}\",\"score\":10,\"playerName\":\"${USERNAME}\"}" \
   >/dev/null
 echo "[flow] GameScore POST ok"
 
-curl -fsS "${h_app[@]}" "${h_master[@]}" "${base}/classes/GameScore/${SCORE_ID}" \
+curl -fsS -X POST "${h_app[@]}" "${h_master[@]}" "${h_json[@]}" "${base}/classes/PlayerStats" \
+  --data "{\"objectId\":\"${PLAYER_ID}\",\"level\":1,\"xp\":100,\"playerName\":\"${USERNAME}\"}" \
   >/dev/null
-echo "[flow] GameScore GET ok"
+echo "[flow] PlayerStats POST ok"
+
+curl -fsS -X POST "${h_app[@]}" "${h_master[@]}" "${h_json[@]}" "${base}/classes/Achievement" \
+  --data "{\"objectId\":\"${ACHIEVEMENT_ID}\",\"name\":\"first-class\",\"unlocked\":true}" \
+  >/dev/null
+echo "[flow] Achievement POST ok"
+
+# --- Tier 4: read-after-mutation. Each call may cause Parse Server
+# to consult its schema cache (recently invalidated by the inserts
+# above), capturing more post-mutation find _SCHEMA mocks. ---
+
+curl -fsS "${h_app[@]}" "${h_master[@]}" "${base}/classes/GameScore/${SCORE_ID}"     >/dev/null
+curl -fsS "${h_app[@]}" "${h_master[@]}" "${base}/classes/PlayerStats/${PLAYER_ID}"  >/dev/null
+curl -fsS "${h_app[@]}" "${h_master[@]}" "${base}/classes/Achievement/${ACHIEVEMENT_ID}" >/dev/null
+curl -fsS -X PUT "${h_app[@]}" "${h_master[@]}" "${h_json[@]}" "${base}/classes/GameScore/${SCORE_ID}" \
+  --data '{"score":99}' >/dev/null
+curl -fsS "${h_app[@]}" "${h_master[@]}" "${base}/schemas"                           >/dev/null
+curl -fsS "${h_app[@]}" "${h_master[@]}" "${base}/schemas/GameScore"                 >/dev/null
+echo "[flow] tier 4 (read-after-mutation) done"
 
 echo "[flow] complete"


### PR DESCRIPTION
## Summary

Enriches the `parse-server-mongo` sample's `flow.sh` from a 3-call minimal reproducer to a 14-call flow that reliably triggers the chronology divergence the mongo/v2 boot-phase tiebreaker bug ([keploy/integrations#166](https://github.com/keploy/integrations/pull/166)) needs at replay.

## Why

The original 3-call flow (signup → POST GameScore → GET GameScore) was tight enough that the recording sometimes captured only a single same-shape `find _SCHEMA filter:{}` snapshot. With only one candidate, the matcher's score-tied tiebreaker has nothing to contend over, and the falsifying-lane assertions in keploy/integrations#166 passed even against the unfixed `keploy-latest` binary in the `record-build-replay-latest` matrix cell — defeating the purpose of the cross-binary matrix.

## Enrichment shape

| Tier | Calls | Purpose |
|---|---|---|
| 1 | `GET /health`, `GET /serverInfo`, `GET /config`, `GET /schemas` | Read-only probes; each may cause Parse Server to refresh its schema cache, capturing more pre-mutation `find _SCHEMA` snapshots |
| 2 | `POST /users` (signup), `GET /login` | _Session-tier mutations; no user-class mutation |
| 3 | `POST /classes/GameScore`, `POST /classes/PlayerStats`, `POST /classes/Achievement` | Three user-class insertions. Each mutates `_SCHEMA`, refreshes Parse Server's schema cache, and captures a fresh `find _SCHEMA` snapshot with the larger class set |
| 4 | `GET /classes/<each>/<id>`, `PUT /classes/GameScore/<id>`, `GET /schemas`, `GET /schemas/GameScore` | Read-after-mutation, ensures post-mutation snapshots land in the recording |

A 3-second `sleep` after `parse-server` health check lets the eager-index sweep at boot complete before flow drives any traffic, so multiple pre-mutation `find _SCHEMA` captures land before tier 3.

End-to-end this produces ≥ 4 distinct `find _SCHEMA filter:{}` response shapes in `mocks.yaml`:

- empty / system-only (boot)
- `+ GameScore`
- `+ GameScore, + PlayerStats`
- `+ GameScore, + PlayerStats, + Achievement`

That's wide enough that the unfixed tiebreaker will reliably pick a post-mutation mock at replay, the booting app will run a `listIndexes` query whose mock the recording never captured at boot phase, and the keploy/integrations falsifying lane's `record-build-replay-latest` cell goes red against the unfixed `keploy-latest` — proving the bug exists.

## Test plan

- [x] `flow.sh` syntax validated (`bash -n`)
- [ ] Verified end-to-end via the keploy/integrations parse-server-mongo lane on PR #166 (the lane will be re-pinned to `chore/enrich-parse-server-mongo-flow` until this PR merges)

## Refs

- [keploy/integrations#166](https://github.com/keploy/integrations/pull/166) — the matcher fix; this enrichment ensures its e2e lane is genuinely falsifying
- [keploy/samples-typescript#94](https://github.com/keploy/samples-typescript/pull/94) — the original sample
- [keploy/keploy#4158](https://github.com/keploy/keploy/pull/4158) — the merged keploy companion (DeleteStartupMock)