### PR TITLE
chore: replace the slack url to updated invite url

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,7 +20,7 @@ The following behaviors are expected and requested of all community members:
  * Show consideration and respect in all your actions and speech. Avoid any behavior that is demeaning, discriminatory, or harassing.
  * Seek collaboration as an initial step instead of conflict.
  * Refrain from demeaning, discriminatory, or harassing behavior and speech.
- * Report any unsafe situations, distress or violations of the code of conduct to the maintainers through [Slack](https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg).
+ * Report any unsafe situations, distress or violations of the code of conduct to the maintainers through [Slack](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA).
 * Practice empathy and kindness towards other community members.
 * Respect diverse opinions, perspectives, and experiences.
 * Give and receive constructive feedback in a gracious manner.
@@ -116,7 +116,7 @@ the community.
 
 ## Contact info
 
-* [Slack](https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg)
+* [Slack](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
 * [Mail](hello@keploy.io)
 
 ## Support 🙏 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <a href="CODE_OF_CONDUCT.md" alt="Contributions welcome">
     <img src="https://img.shields.io/badge/Contributions-Welcome-brightgreen?logo=github" /></a>
     
-  <a href="https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg" alt="Slack">
+  <a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA" alt="Slack">
     <img src="https://github.com/keploy/samples-go/blob/main/.github/slack.svg?raw=true" /></a>
     
   <a href="https://opensource.org/licenses/Apache-2.0" alt="License">
@@ -34,7 +34,7 @@ This repo contains the sample for [Keploy's](https://keploy.io) JS Application. 
 ### 🤔 Questions?
 Reach out to us. We're here to help!
 
-[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg)
+[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
 [![LinkedIn](https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/keploy/)
 [![YouTube](https://img.shields.io/badge/YouTube-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white)](https://www.youtube.com/channel/UC6OTg7F4o0WkmNtSoob34lg)
 [![Twitter](https://img.shields.io/badge/Twitter-%231DA1F2.svg?style=for-the-badge&logo=Twitter&logoColor=white)](https://twitter.com/Keployio)


### PR DESCRIPTION
## Summary

- Updated the Slack community invite URL across the repository to the new valid link.
- Old URL (`zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg`) replaced in 2 files:
  - `README.md` (2 occurrences — badge link and anchor tag)
  - `CODE_OF_CONDUCT.md` (2 occurrences — Expected Behavior section and Contact Info section)

## Why

The previous Slack invite link had expired/rotated. This ensures contributors and community members can successfully join the Keploy Slack workspace.

## Changes

| File | Occurrences Updated |
|------|-------------------|
| `README.md` | 2 |
| `CODE_OF_CONDUCT.md` | 2 |

No functional code changes — docs only.
