### PR TITLE
fix(node-dependency-matrix): count gRPC test cases in recording calibration (0 → 2)

### DIFF
--- a/node-dependency-matrix/fixtures/expected-values.json
+++ b/node-dependency-matrix/fixtures/expected-values.json
@@ -349,7 +349,7 @@
     ],
     "grpcTrafficScript": {
       "path": "scripts/send_grpc_traffic.sh",
-      "expectedAdditionalTestcasesExact": 0,
+      "expectedAdditionalTestcasesExact": 2,
       "calls": [
         {
           "method": "/dependencymatrix.DependencyMatrix/Ping",


### PR DESCRIPTION
## 📝 Description

**Problem**

The kube-regression suite (enterprise-ui, `kube-flow.spec.ts` test 8) asserts that the number of recorded test cases stays at or below a calibrated total read from this sample's `fixtures/expected-values.json`:

```
getExpectedTotalTestcases() = httpTrafficScript.expectedTestcasesExact
                            + grpcTrafficScript.expectedAdditionalTestcasesExact
```

`expectedAdditionalTestcasesExact` was pinned at `0` because, at calibration time, k8s-proxy silently dropped gRPC test cases from the recording session — `processTestCase` only counted entries with a non-empty `HTTPReq.URL`, so the two gRPC calls in `send_grpc_traffic.sh` never incremented the recorded total. Observed gRPC contribution was genuinely 0.

k8s-proxy [PR #542](https://github.com/keploy/k8s-proxy/pull/542) now records gRPC test cases (recognizes `GRPC_EXPORT`, populates the endpoint list, increments `TestsRecorded`). With that change the recording produces **21** test cases (19 HTTP + 2 gRPC), tripping the assertion:

```
Error: Recorded test cases should not exceed the calibrated dedup total
Expected: <= 19
Received:    21
```

**Fix**

Bump `grpcTrafficScript.expectedAdditionalTestcasesExact` from `0 → 2`, so the calibrated total becomes `19 + 2 = 21` and matches the recorded reality once gRPC cases are counted.

This just reconciles the aggregate with the per-call values already declared in the same file — both gRPC calls (`Ping`, `RunDependencyScenario`) already carry `expectedAdditionalTestcases: 1`.

## 🔄 Change

- `node-dependency-matrix/fixtures/expected-values.json`: `expectedAdditionalTestcasesExact` `0 → 2` (1 line)

## ✅ Compatibility

The kube-regression assertion is a `<=` ceiling, so raising it is backward-compatible:
- **Released k8s-proxy** (records 19): `19 <= 21` ✅
- **k8s-proxy PR #542** (records 21): `21 <= 21` ✅

No ordering dependency with PR #542 — this can merge before or after it without breaking any consumer.

## 🧪 Testing

Validated against k8s-proxy PR #542's `playwright-kube-regression` pipeline by temporarily pointing `SAMPLES_TYPESCRIPT_REF` at this change. Test 8 went green with `Test cases=21` and the full record → auto-replay flow completed:

```
Attempt 1/30: Test cases=21, Mocks=52, ... ready=true
✓ 8. Assert dedup data matches expected-values.json (10.8s)
```

Related: keploy/k8s-proxy#542